### PR TITLE
refactor(home)

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,3 +5,4 @@ export { InputRoot, InputField, InputIcon, InputLabel, InputMessage } from "./In
 export { Section, SectionBox, SectionApp } from "./Section";
 export { Shape } from "./Shape";
 export { AppHeader } from "./AppHeader";
+export { CloudinaryImage } from "./CloudinaryImage";

--- a/src/pages/app/home/index.jsx
+++ b/src/pages/app/home/index.jsx
@@ -1,124 +1,185 @@
-import { Button, ButtonText, SectionApp } from "@/components";
-import { Package, UserCircle, Truck, Star, WhatsappLogo, ArrowSquareOut, EnvelopeSimple, Cube, List, FolderSimpleStar, ClipboardText } from "phosphor-react";
+import {
+  Button,
+  ButtonText,
+  SectionApp,
+  Shape,
+  CloudinaryImage,
+} from "@/components";
+import {
+  Package,
+  UserCircle,
+  Truck,
+  Star,
+  WhatsappLogo,
+  ArrowSquareOut,
+  EnvelopeSimple,
+  Cube,
+  List,
+  FolderSimpleStar,
+  ClipboardText,
+  Gear,
+} from "phosphor-react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 
 export function Home() {
+  const [showWhatsApp, setShowWhatsApp] = useState(false);
+  const toggleWhatsApp = () => setShowWhatsApp((prev) => !prev);
+
   const serviceButtons = [
     {
       to: "/app/orcamento",
       className: "lg:order-1",
       buttonClass: "bg-red-tx",
       icon: <Package className="text-white icon" />,
-      children: <ButtonText className="text-white">Solicitar orçamento</ButtonText>,
+      children: (
+        <ButtonText className="text-white">Solicitar orçamento</ButtonText>
+      ),
     },
     {
       to: "/app/minhas-solicitacoes",
       className: "lg:order-3",
       buttonClass: "bg-white border border-gray-600",
       icon: <ClipboardText className="text-red-tx icon" />,
-      children: <ButtonText className="text-black">Ver minhas Solicitações</ButtonText>,
+      children: (
+        <ButtonText className="text-black">Ver minhas solicitações</ButtonText>
+      ),
     },
     {
       to: "/app/rotas-atendidas",
       className: "lg:order-5",
       buttonClass: "bg-white border border-gray-600",
       icon: <Truck className="text-red-tx icon" />,
-      children: <ButtonText className="text-black">Ver rotas atendidas</ButtonText>,
+      children: (
+        <ButtonText className="text-black">Ver rotas atendidas</ButtonText>
+      ),
     },
+  ];
+
+  const getDayPeriod = () => {
+    const hour = new Date().getHours();
+    if (hour >= 5 && hour < 12) return "bom dia";
+    if (hour >= 12 && hour < 18) return "boa tarde";
+    return "boa noite";
+  };
+
+  const reviewButtons = [
     {
       to: "/app/avaliar",
       className: "lg:order-4",
       buttonClass: "bg-white border border-gray-600",
       icon: <Star className="text-red-tx icon" />,
-      children: <ButtonText className="text-black">Avaliar nosso serviço</ButtonText>,
+      children: (
+        <ButtonText className="text-black">Avaliar nosso serviço</ButtonText>
+      ),
     },
     {
       to: "/app/minhas-avaliacoes",
       className: "lg:order-6",
       buttonClass: "bg-white border border-gray-600",
       icon: <FolderSimpleStar className="text-red-tx icon" />,
-      children: <ButtonText className="text-black">Ver minhas avaliações</ButtonText>,
-    },
-    {
-      to: "https://wa.me/5544999965596",
-      external: true,
-      className: "lg:order-7",
-      buttonClass: "bg-white border border-gray-600",
-      icon: <WhatsappLogo className="text-red-tx icon" />,
-      arrowOut: true,
-      children: <ButtonText className="text-black">WhatsApp 1</ButtonText>,
-    },
-    {
-      to: "https://wa.me/5544920001842",
-      external: true,
-      className: "lg:order-8",
-      buttonClass: "bg-white border border-gray-600",
-      icon: <WhatsappLogo className="text-red-tx icon" />,
-      arrowOut: true,
-      children: <ButtonText className="text-black">WhatsApp 2</ButtonText>,
-    },
-    {
-      to: "mailto:teruelexpress.servicos@gmail.com",
-      external: true,
-      className: "lg:order-2",
-      buttonClass: "bg-white border border-gray-600",
-      icon: <EnvelopeSimple className="text-red-tx icon" />,
-      arrowOut: true,
-      children: <ButtonText className="text-black">Enviar email</ButtonText>,
+      children: (
+        <ButtonText className="text-black">Ver minhas avaliações</ButtonText>
+      ),
     },
   ];
 
   return (
-    <>
-      <SectionApp>
-        <div className="max-w-sm sm:max-w-lg lg:max-w-3xl mx-auto">
-          <div className="flex flex-col items-center gap-10 lg:gap-15 pb-20">
-            <div className="items-center w-full">
-              <div className="flex-1 flex justify-center">
-                <h3 className="text-black">Página inicial</h3>
-              </div>
-            </div>
-            <Button className="bg-gray-100 w-60 h-12">
-              <UserCircle className="text-gray-600 icon" />
-              <p className="text-black font-bold">Minha conta</p>
-            </Button>
+    <SectionApp>
+      <div className="max-w-sm sm:max-w-lg lg:max-w-3xl mx-auto">
+        <div className="flex flex-col items-center">
+          <div className="items-center flex justify-center w-full">
+            <CloudinaryImage
+              publicId={"ndmrywtuuk65gxfo8onn"}
+              className="w-48 sm:w-58 h-auto "
+            />
           </div>
-          <div className="grid grid-cols-1 gap-3 lg:gap-6 lg:grid-cols-2">
-            <h4 className="lg:col-span-2">Serviços</h4>
-            {serviceButtons.map((props, idx) => (
-              <ServiceButtonLink key={idx} {...props} />
-            ))}
+          <div className="flex-1 flex justify-center">
+            <span className="text-black pb-10 text-2xl sm:text-4xl font-heading">
+              Olá, {getDayPeriod()} João!
+            </span>
           </div>
         </div>
-      </SectionApp>
-    </>
+        <div className="rounded-2xl px-3 py-2 sm:p-3 gap-x-2 flex items-center mb-5 shadow-sm drop-shadow-primary border-gray-50 xs:border-1 text-black ">
+          <UserCircle size={48}/>
+          <div className="flex flex-col w-full">
+            <span className="font-heading text-sm text-gray-600">Pessoa física</span>
+            <span className="font-heading text-xl">João Silva</span>
+          </div>
+          <Gear className="icon hover:cursor-pointer"/>
+        </div>
+        <div className="grid grid-cols-1 gap-y-5 gap-x-5 lg:grid-cols-2">
+          <Shape className="p-0 xs:p-4 sm:p-4 xl:p-6 xs:shadow-sm drop-shadow-primary border-gray-50 xs:border-1">
+            <h4 className="lg:col-span mb-4">Frete</h4>
+            <div className="grid grid-cols-1 gap-3 lg:gap-6">
+              {serviceButtons.map((props, idx) => (
+                <ServiceButtonLink key={idx} {...props} />
+              ))}
+            </div>
+          </Shape>
+          <Shape className="p-0 xs:p-4 sm:p-4 xl:p-6 xs:shadow-sm drop-shadow-primary border-gray-50 xs:border-1">
+            <h4 className="lg:col-span mb-4">Outros</h4>
+            <div className="grid grid-cols-1 gap-3 lg:gap-6">
+              {reviewButtons.map((props, idx) => (
+                <ServiceButtonLink key={idx} {...props} />
+              ))}
+            </div>
+          </Shape>
+        </div>
+      </div>
+      <div className="fixed right-2 bottom-2 sm:right-8 sm:bottom-8 space-y-2 sm: space-y-4">
+        {showWhatsApp && <WhatsAppNumbers toggle={toggleWhatsApp}/>}
+        <div className="flex gap-2 sm:gap-4 justify-end">
+          <Button className="size-12 flex justify-around sm:size-16 sm:aspect-square bg-blue-500  ">
+            <EnvelopeSimple size={36} className="text-white" />
+          </Button>
+          <Button className="size-12 flex justify-around sm:size-16 sm:aspect-square bg-success-base  " onClick={toggleWhatsApp}>
+            <WhatsappLogo size={36} className="text-white" />
+          </Button>
+        </div>
+      </div>
+    </SectionApp>
+  );
+}
+
+function WhatsAppNumbers({ toggle }) {
+  return (
+    <div className=" flex flex-col gap-y-2" >
+      <Link to="https://wa.me/5544999965596" target="_blank" >
+      <Button className="flex w-50  bg-success-base text-white" onClick={toggle}>
+        <WhatsappLogo className="icon " />
+        <ButtonText>WhatsApp 1</ButtonText>
+      </Button>
+      </Link> 
+      <Link to="https://wa.me/5544920001842" target="_blank" >
+      <Button className="flex w-50  bg-success-base text-white" onClick={toggle}>
+        <WhatsappLogo className="icon " />
+        <ButtonText>WhatsApp 2</ButtonText>
+      </Button>
+      </Link>
+    </div>
   );
 }
 
 function ServiceButtonLink({
   to,
   external = false,
-  className = '',
-  buttonClass = '',
+  className = "",
+  buttonClass = "",
   icon,
   children,
   arrowOut = false,
 }) {
   const linkProps = external
-    ? { to, target: '_blank', rel: 'noopener noreferrer' }
+    ? { to, target: "_blank", rel: "noopener noreferrer" }
     : { to };
 
   return (
-    <Link
-      {...linkProps}
-      className={className}
-    >
+    <Link {...linkProps} className={className}>
       <Button className={buttonClass}>
         {icon}
         {children}
-        {arrowOut && (
-          <ArrowSquareOut className="text-gray-600 icon" />
-        )}
+        {arrowOut && <ArrowSquareOut className="text-gray-600 icon" />}
       </Button>
     </Link>
   );

--- a/src/pages/app/screens/MyShipments.jsx
+++ b/src/pages/app/screens/MyShipments.jsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/ui/table";
 
 import {Button} from "@/components/ui/button"
+import { X } from "phosphor-react";
 
 export function MyShipments() {
   return (
@@ -46,9 +47,10 @@ export function MyShipments() {
 const data = [
   {
     id: "m5gr84i9",
-    amount: 316,
+    amount: 10,
     status: "success",
     email: "ken99@example.com",
+    cancelar: "X"
   },
   {
     id: "3u1reuv4",
@@ -90,7 +92,7 @@ const columns = [
       />
     ),
     cell: ({ row }) => (
-      <Checkbox
+      <X
         checked={row.getIsSelected()}
         onCheckedChange={value => row.toggleSelected(!!value)}
         aria-label="Select row"
@@ -118,6 +120,19 @@ const columns = [
       </Button>
     ),
     cell: ({ row }) => <div className="lowercase">{row.getValue("email")}</div>,
+  },
+  {
+    accessorKey: "cancelar",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Cancelar
+        
+      </Button>
+    ),
+    cell: ({ row }) => <div>{row.getValue("cancelar")}</div>,
   },
   {
     accessorKey: "amount",
@@ -224,11 +239,11 @@ function DataTableDemo() {
       </div>
       <div className="rounded-md border">
         <Table>
-          <TableHeader>
+          <TableHeader >
             {table.getHeaderGroups().map(headerGroup => (
-              <TableRow key={headerGroup.id}>
+              <TableRow key={headerGroup.id} >
                 {headerGroup.headers.map(header => (
-                  <TableHead key={header.id}>
+                  <TableHead key={header.id} className="text-center">
                     {header.isPlaceholder
                       ? null
                       : flexRender(
@@ -243,7 +258,7 @@ function DataTableDemo() {
           <TableBody>
             {table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map(row => (
-                <TableRow
+                <TableRow className="text-center"
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
                 >


### PR DESCRIPTION
### O que foi feito?
- Reorganiza seção home para trazer um design mais limpo e intuitivo: botões whatsapp condensados para um único link no canto dela, assim como o botão de email. 
- Adiciona cards "Frete" e "Outros" para agrupar botões relacionados. 
- Torna o botão "Minha conta" em um card horizontalizado mais apresentável, com o nome do cliente, tipo de conta, e uma engrenagem para a futura configuração de conta.
- Adiciona mensagem inicial, saudando o cliente com o seu nome, similar ao Gemini do Google.
- Remove título "Página inicial", e adiciona logo da empresa na tela inicial

OBS:
- Não tive tempo hábil para prototipar a tela home adequadamente, então venho por meio deste refactor entregar algo mais próximo de um design final.

